### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes will be documented here.
 
-## Upcoming
+## v2.2.0 - 2021-05-15
 
 ### Changes
 
@@ -15,7 +15,7 @@ All notable changes will be documented here.
 
 ### Upgrading
 
-- When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` column   
+- When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` string-column   
   `$table->string('route_domain')->nullable();`
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ When changes are made that impact existing users, I will make sure that they are
 
 These will contain changes like database columns added / removed / renamed. Or functional changes that need action within your code.
 
+#### v2.1.x to v2.2.x
+
+- When updating from v2.1 to v2.2 add a nullable `route_domain` string-column to the `swagger_batches` domain.   
+  `$table->string('route_domain')->nullable();`
+
 ## Usage
 
 ### Registering the Redoc Documentation route.
@@ -249,4 +254,4 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 
 ## Changelog
 
-All notable changes can be found in the [CHANGELOG.md](docs/CHANGELOG.md).
+All notable changes can be found in the [CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -121,12 +121,11 @@ return [
 ];
 ```
 
-### Swagger Meta Information and Servers
+### Swagger Meta Information
 
-Swagger allows you to provide the users with a bit of info about your API; a title, a description and a version, and also an unlimited amount of servers to display in your UI.
+Swagger allows you to provide the users with a bit of info about your API; a title, a description and a version.
 
-In the config there is a `swagger.info` array where you can add your API's title, description and version, as shown below.  
-There is also a `swagger.servers` array where you can add all the servers you'd like.
+In the config there is a `swagger.info` array where you can add your API's title, description and version, as shown below.
 
 ```php
 return [
@@ -136,6 +135,18 @@ return [
         'description' => null,
         'version'     => '2.1.2',
     ],
+    //...
+];
+```
+
+### Swagger Servers
+
+Swagger allows you to show the user servers that you can access the API from. A basic setup would be the one below;
+
+- You have one API where your users can access live data and one where they can access some demo information.
+
+```php
+return [
     //...
     'servers'          => [
         [
@@ -151,13 +162,65 @@ return [
 ];
 ```
 
-> _Currently the package does not support [Server templating](https://swagger.io/docs/specification/api-host-and-base-path), although I do plan on adding it [in the future](https://github.com/RicoNijeboer/laravel-to-swagger/issues/6)_
+#### Server templating
+
+Swagger also supports [Server templating](https://swagger.io/docs/specification/api-host-and-base-path/). You are able to add variables to your server which gives you the possibility to obfuscate the
+urls a bit.
+
+An example from their documentation is a server where you have `https://{customerId}.saas-app.com:{port}/v2` as the URL. This is translated to their Yaml as shown below. They define the url,
+containing its variables, and describe what the variables do and what their default values are.
+
+Laravel to Swagger supports basically the same format as the Yaml file, below the Yaml you can see how you translate it to the Swagger config. I've added very light validation to this, so if the
+Swagger UI / Redoc UI breaks try to first ensure that you've correctly configured the config according to the [Swagger docs](https://swagger.io/docs/specification/api-host-and-base-path/)
+
+**Swagger Yaml**
+
+```yaml
+servers:
+  - url: https://{customerId}.saas-app.com:{port}/v2
+    variables:
+      customerId:
+        default: demo
+        description: Customer ID assigned by the service provider
+      port:
+        enum:
+          - '443'
+          - '8443'
+        default: '443'
+```
+
+**Laravel to Swagger Config**
+
+```php
+return [
+    //...
+    'servers'          => [
+        [
+            'url'       => 'https://{customerId}.saas-app.com:{port}/v2',
+            'variables' => [
+                'customerId' => [
+                    'default'     => 'demo',
+                    'description' => 'Customer ID assigned by the service provider',
+                ],
+                'port'       => [
+                    'enum'    => [
+                        '443',
+                        '8443',
+                    ],
+                    'default' => '443',
+                ],
+            ],
+        ],
+    ],
+    //...
+];
+```
 
 ### Redoc Version
 
-Let's say you run into a bug within the Redoc that the team behind Redoc has fixed in a newer version, and I have not updated the package yet to have the fixed version used.
-I have added a config value (`swagger.redoc.version`), so you don't have to mess around with things like published views or anything;
-You can simply change the version based on their [releases](https://github.com/Redocly/redoc/releases), at the time of writing this documentation the latest version is `v2.0.0-rc.53`.
+Let's say you run into a bug within the Redoc that the team behind Redoc has fixed in a newer version, and I have not updated the package yet to have the fixed version used. I have added a config
+value (`swagger.redoc.version`), so you don't have to mess around with things like published views or anything; You can simply change the version based on
+their [releases](https://github.com/Redocly/redoc/releases), at the time of writing this documentation the latest version is `v2.0.0-rc.53`.
 
 ```php
 return [

--- a/database/factories/EntryFactory.php
+++ b/database/factories/EntryFactory.php
@@ -56,4 +56,12 @@ class EntryFactory extends Factory
             'content' => $parameters ?? [],
         ]);
     }
+
+    public function wheres(array $wheres = null): self
+    {
+        return $this->state(fn () => [
+            'type'    => Entry::TYPE_ROUTE_WHERES,
+            'content' => $wheres ?? [],
+        ]);
+    }
 }

--- a/database/migrations/create_swagger_batches_table.php.stub
+++ b/database/migrations/create_swagger_batches_table.php.stub
@@ -15,6 +15,7 @@ class CreateSwaggerBatchesTable extends Migration
             $table->string('route_method');
             $table->string('route_uri');
             $table->string('route_name')->nullable();
+            $table->string('route_domain')->nullable();
             $table->text('route_middleware');
 
             $table->timestamps();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes will be documented here.
 
+## Upcoming
+
+- When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.
+  - When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` column   
+    `$table->string('route_domain')->nullable();`
+
 ## v2.1.1 - 2021-05-15
 
 **Bugfixes**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes will be documented here.
 
 ### Changes
 
-- When a route-parameter has a `where` (or `format` in Swagger terms) it now adds this in the Swagger config.
+- When a field in your request validation has a [`regex`](https://laravel.com/docs/8.x/validation#rule-regex) rule. It gets a `format` rule within the Swagger config.
+- When a route-parameter has a [`where`](https://laravel.com/docs/8.x/routing#parameters-regular-expression-constraints) (or `format` in Swagger terms) it now adds this in the Swagger config.
 - Added support for [server templating](https://github.com/RicoNijeboer/laravel-to-swagger/issues/4).
 - OAuth URLs are now relative when you don't supply a custom domain to them.
 - When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes will be documented here.
 - Added support for [server templating](https://github.com/RicoNijeboer/laravel-to-swagger/issues/4).
 - OAuth URLs are now relative when you don't supply a custom domain to them.
 - When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.
+- The `SwaggerReader` and `SwaggerTag` are now [Terminable Middlewares](https://laravel.com/docs/8.x/middleware#terminable-middleware), which means your users should feel even less of an impact when using your app
 
 ### Upgrading
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes will be documented here.
 ## Upcoming
 
 ### Changes
+- Added support for [server templating](https://github.com/RicoNijeboer/laravel-to-swagger/issues/4).
 - OAuth URLs are now relative when you don't supply a custom domain to them.
 - When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.
     

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes will be documented here.
 
 ## Upcoming
 
+### Changes
+- OAuth URLs are now relative when you don't supply a custom domain to them.
 - When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.
-  - When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` column   
-    `$table->string('route_domain')->nullable();`
+    
+### Upgrading
+
+- When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` column   
+  `$table->string('route_domain')->nullable();`
+
+---
 
 ## v2.1.2 - 2021-05-15
 
@@ -16,11 +23,15 @@ All notable changes will be documented here.
   - To ensure your tables are created in the right connection add a `connection` call to the `Schema::create` in the migration.    
     `Schema::connection(config('swagger.database.connection'))`
 
+---
+
 ## v2.1.1 - 2021-05-15
 
 **Bugfixes**
 
 - Fixed a bug where existing batches without a parameter entry would make your config get corrupted.
+
+---
 
 ## v2.1.0 - 2021-05-15
 
@@ -32,9 +43,13 @@ All notable changes will be documented here.
 
 - Fixed a bug with foreign key constraints not cascade deleting
 
+---
+
 ## v2.0.0 - 2021-05-14
 
 - Responses are now calculated and sent to the config as well.
+
+---
 
 ## Changes since version 1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes will be documented here.
 ## Upcoming
 
 ### Changes
+
+- When a route-parameter has a `where` (or `format` in Swagger terms) it now adds this in the Swagger config.
 - Added support for [server templating](https://github.com/RicoNijeboer/laravel-to-swagger/issues/4).
 - OAuth URLs are now relative when you don't supply a custom domain to them.
 - When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.
-    
+
 ### Upgrading
 
 - When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` column   
@@ -21,8 +23,8 @@ All notable changes will be documented here.
 **Bugfixes**
 
 - The configured connection was not being used within the added migrations.
-  - To ensure your tables are created in the right connection add a `connection` call to the `Schema::create` in the migration.    
-    `Schema::connection(config('swagger.database.connection'))`
+    - To ensure your tables are created in the right connection add a `connection` call to the `Schema::create` in the migration.    
+      `Schema::connection(config('swagger.database.connection'))`
 
 ---
 

--- a/src/Actions/BuildOpenApiConfigAction.php
+++ b/src/Actions/BuildOpenApiConfigAction.php
@@ -139,6 +139,10 @@ class BuildOpenApiConfigAction
             $batchConfig['parameters'] = $pathData->parameters;
         }
 
+        if (!empty($pathData->servers)) {
+            $batchConfig['servers'] = $pathData->servers;
+        }
+
         if ($batch->tags()->exists()) {
             $batchConfig['tags'] = $batch->tags->pluck('tag')->toArray();
         }

--- a/src/Actions/ObfuscateJsonAction.php
+++ b/src/Actions/ObfuscateJsonAction.php
@@ -69,9 +69,6 @@ class ObfuscateJsonAction
             return null;
         }
 
-        ray($value);
-        ray()->pause();
-
         return $value;
     }
 

--- a/src/Actions/ReadRouteInformationAction.php
+++ b/src/Actions/ReadRouteInformationAction.php
@@ -43,6 +43,7 @@ class ReadRouteInformationAction
         $batch->route_method = strtoupper($method);
         $batch->route_uri = $route->uri();
         $batch->route_name = $route->getName();
+        $batch->route_domain = $route->getDomain();
         $batch->route_middleware = $route->gatherMiddleware();
 
         $batch->save();

--- a/src/Actions/ReadRouteInformationAction.php
+++ b/src/Actions/ReadRouteInformationAction.php
@@ -31,10 +31,18 @@ class ReadRouteInformationAction
         $batch = $this->createBatch(strtoupper($request->getMethod()), $route, $response);
 
         $parametersEntry = $this->createParametersEntry($batch, $route);
+        $parametersEntry = $this->createParametersWheresEntry($batch, $route);
         $rulesEntry = $this->createRulesEntry($batch, $rules);
         $responseEntry = $this->createResponseEntry($batch, $response);
     }
 
+    /**
+     * @param string          $method
+     * @param Route           $route
+     * @param SymfonyResponse $response
+     *
+     * @return Batch
+     */
     protected function createBatch(string $method, Route $route, SymfonyResponse $response): Batch
     {
         $batch = new Batch();
@@ -51,6 +59,12 @@ class ReadRouteInformationAction
         return $batch;
     }
 
+    /**
+     * @param Batch $batch
+     * @param array $rules
+     *
+     * @return Entry
+     */
     protected function createRulesEntry(Batch $batch, array $rules = []): Entry
     {
         $entry = new Entry();
@@ -64,6 +78,12 @@ class ReadRouteInformationAction
         return $entry;
     }
 
+    /**
+     * @param Batch           $batch
+     * @param SymfonyResponse $response
+     *
+     * @return Entry
+     */
     protected function createResponseEntry(Batch $batch, SymfonyResponse $response): Entry
     {
         $entry = new Entry();
@@ -80,6 +100,12 @@ class ReadRouteInformationAction
         return $entry;
     }
 
+    /**
+     * @param Batch $batch
+     * @param Route $route
+     *
+     * @return Entry
+     */
     protected function createParametersEntry(Batch $batch, Route $route): Entry
     {
         $entry = new Entry();
@@ -89,7 +115,7 @@ class ReadRouteInformationAction
         $entry->content = collect($route->parameters())->mapWithKeys(function ($value, string $parameter) use ($route) {
             $parameterValue = $route->parameter($parameter);
 
-            preg_match("/\{({$parameter})(:[\w]*)?\}/", $route->uri(), $matches);
+            preg_match("/{({$parameter})(:[\w]*)?}/", $route->uri(), $matches);
 
             return [
                 $parameter => [
@@ -98,6 +124,25 @@ class ReadRouteInformationAction
                 ],
             ];
         });
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
+     * @param Batch $batch
+     * @param Route $route
+     *
+     * @return Entry
+     */
+    protected function createParametersWheresEntry(Batch $batch, Route $route): Entry
+    {
+        $entry = new Entry();
+        $entry->batch()->associate($batch);
+
+        $entry->type = Entry::TYPE_ROUTE_WHERES;
+        $entry->content = $route->wheres;
 
         $entry->save();
 

--- a/src/Data/PathData.php
+++ b/src/Data/PathData.php
@@ -22,6 +22,8 @@ class PathData
 
     public string $summary;
 
+    public array $servers = [];
+
     public array $parameters = [];
 
     public array $requiredProperties = [];
@@ -57,7 +59,8 @@ class PathData
         $this->method = strtolower($batch->route_method);
         $this->summary = $batch->route_name ?? $batch->route_uri;
 
-        $this->calculateParameters($batch)
+        $this->calculateServers($batch)
+            ->calculateParameters($batch)
             ->calculateProperties($batch)
             ->calculateRequired($batch)
             ->calculateResponse($batch);
@@ -151,6 +154,11 @@ class PathData
         }
     }
 
+    /**
+     * @param Batch $batch
+     *
+     * @return $this
+     */
     protected function calculateParameters(Batch $batch): self
     {
         if ($batch->parameterEntry()->doesntExist()) {
@@ -175,6 +183,24 @@ class PathData
             })
             ->values()
             ->all();
+
+        return $this;
+    }
+
+    /**
+     * @param Batch $batch
+     *
+     * @return $this
+     */
+    protected function calculateServers(Batch $batch): PathData
+    {
+        $this->servers = [];
+
+        if (!empty($batch->route_domain)) {
+            $this->servers[] = [
+                'url' => $batch->route_domain,
+            ];
+        }
 
         return $this;
     }

--- a/src/Data/PathData.php
+++ b/src/Data/PathData.php
@@ -167,17 +167,23 @@ class PathData
             return $this;
         }
 
+        $formats = optional(optional($batch->parameterWheresEntry)->content)->getArrayCopy() ?? [];
+
         $this->parameters = collect($batch->parameterEntry->content)
-            ->map(function (array $data, string $parameter) {
+            ->map(function (array $data, string $parameter) use ($formats) {
                 ['class' => $class, 'required' => $required] = $data;
+
+                $hasFormat = array_key_exists($parameter, $formats);
 
                 return [
                     'in'          => 'path',
                     'required'    => $required,
                     'name'        => $parameter,
-                    'schema'      => [
+                    'schema'      => array_merge([
                         'type' => 'string',
-                    ],
+                    ], array_filter([
+                        'format' => $hasFormat ? $formats[$parameter] : null,
+                    ])),
                     'description' => $class === 'string' ? Str::studly($parameter) : class_basename($class),
                 ];
             })

--- a/src/Exceptions/MalformedServersException.php
+++ b/src/Exceptions/MalformedServersException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace RicoNijeboer\Swagger\Exceptions;
+
+use Exception;
+use Illuminate\Support\MessageBag;
+
+/**
+ * Class MalformedServersException
+ *
+ * @package RicoNijeboer\Swagger\Exceptions
+ */
+class MalformedServersException extends Exception
+{
+    public function __construct(MessageBag $errors)
+    {
+        ray($errors);
+        parent::__construct();
+    }
+}

--- a/src/Exceptions/MalformedServersException.php
+++ b/src/Exceptions/MalformedServersException.php
@@ -4,6 +4,8 @@ namespace RicoNijeboer\Swagger\Exceptions;
 
 use Exception;
 use Illuminate\Support\MessageBag;
+use Illuminate\Support\Str;
+use RicoNijeboer\Swagger\Support\Concerns\HelperMethods;
 
 /**
  * Class MalformedServersException
@@ -12,9 +14,51 @@ use Illuminate\Support\MessageBag;
  */
 class MalformedServersException extends Exception
 {
+    use HelperMethods;
+
     public function __construct(MessageBag $errors)
     {
-        ray($errors);
-        parent::__construct();
+        parent::__construct($this->formatErrors($errors));
+    }
+
+    /**
+     * @param MessageBag $errors
+     *
+     * @return string
+     */
+    protected function formatErrors(MessageBag $errors): string
+    {
+        $message = 'Whoops. Looks like something went wrong while reading your Swagger servers configuration:';
+        $servers = array_unique(
+            array_map(function (string $key) {
+                preg_match('/servers\.([0-9]+)/', $key, $matches);
+
+                return ((int)array_pop($matches));
+            }, $errors->keys())
+        );
+
+        foreach ($servers as $server) {
+            $message .= PHP_EOL;
+            $message .= PHP_EOL;
+            $message .= "Validation failed with errors for the {$this->ordinal($server + 1)} server:" . PHP_EOL;
+
+            foreach ($errors->get("servers.{$server}.*") as $key => $keyErrors) {
+                $formattedKey = str_replace("servers.{$server}.", '', $key);
+                $formattedKey = str_replace('variables.', '', $formattedKey);
+                $formattedKey = "[{$formattedKey}]";
+
+                if (Str::contains($key, 'variables')) {
+                    $formattedKey = "variable {$formattedKey}";
+                }
+
+                foreach ($keyErrors as $error) {
+                    $message .= ' - ' . str_replace($key, $formattedKey, $error) . PHP_EOL;
+                }
+            }
+        }
+
+        $message = trim($message);
+
+        return $message;
     }
 }

--- a/src/Http/Middleware/SwaggerTag.php
+++ b/src/Http/Middleware/SwaggerTag.php
@@ -5,6 +5,7 @@ namespace RicoNijeboer\Swagger\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use RicoNijeboer\Swagger\Http\Middleware\Concerns\AttachesTagsToBatches;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class SwaggerTag
@@ -24,10 +25,16 @@ class SwaggerTag
      */
     public function handle(Request $request, Closure $next, ...$tags)
     {
-        $response = $next($request);
+        return $next($request);
+    }
 
+    /**
+     * @param Request         $request
+     * @param Response        $response
+     * @param string|string[] ...$tags
+     */
+    public function terminate(Request $request, Response $response, ...$tags)
+    {
         $this->attachTags($request, $response, $tags, true);
-
-        return $response;
     }
 }

--- a/src/Models/Batch.php
+++ b/src/Models/Batch.php
@@ -26,7 +26,8 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  * @property Collection|Entry[] $entries
  * @property Entry              $validationRulesEntry
  * @property Entry              $responseEntry
- * @property Entry              $parameterEntry
+ * @property Entry|null         $parameterEntry
+ * @property Entry|null         $parameterWheresEntry
  * @property Collection|Tag[]   $tags
  * @method static BatchFactory factory(...$parameters)
  * @method static Builder forRequestAndResponse(Request $request, SymfonyResponse $response)
@@ -63,6 +64,15 @@ class Batch extends Model
     {
         return $this->hasOne(Entry::class)
             ->where('type', '=', Entry::TYPE_ROUTE_PARAMETERS);
+    }
+
+    /**
+     * @return HasOne
+     */
+    public function parameterWheresEntry(): HasOne
+    {
+        return $this->hasOne(Entry::class)
+            ->where('type', '=', Entry::TYPE_ROUTE_WHERES);
     }
 
     /**

--- a/src/Models/Batch.php
+++ b/src/Models/Batch.php
@@ -20,7 +20,8 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  * @property int                $response_code
  * @property string             $route_method
  * @property string             $route_uri
- * @property string             $route_name
+ * @property string|null        $route_name
+ * @property string|null        $route_domain
  * @property array              $route_middleware
  * @property Collection|Entry[] $entries
  * @property Entry              $validationRulesEntry

--- a/src/Models/Entry.php
+++ b/src/Models/Entry.php
@@ -24,6 +24,7 @@ class Entry extends Model
 
     const TYPE_VALIDATION_RULES = 'validation/rules';
     const TYPE_ROUTE_PARAMETERS = 'route/parameters';
+    const TYPE_ROUTE_WHERES = 'route/wheres';
     const TYPE_RESPONSE = 'response';
 
     protected $casts = [

--- a/src/Support/Concerns/HelperMethods.php
+++ b/src/Support/Concerns/HelperMethods.php
@@ -75,7 +75,6 @@ trait HelperMethods
             '/\.\d{3}\b/' => '.v',
         ];
         $date = preg_replace(array_keys($patterns), array_values($patterns), $date);
-        ray($date);
 
         return preg_match('/\d/', $date) ? false : $date;
     }

--- a/src/Support/Concerns/HelperMethods.php
+++ b/src/Support/Concerns/HelperMethods.php
@@ -3,7 +3,6 @@
 namespace RicoNijeboer\Swagger\Support\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -19,7 +18,7 @@ trait HelperMethods
     protected function recursively(array $array, string $keyPrefix = ''): Generator
     {
         foreach ($array as $key => $item) {
-            $keyWithPrefix = implode('.', array_filter([$keyPrefix, $key], fn(string $k) => strlen($k) > 0));
+            $keyWithPrefix = implode('.', array_filter([$keyPrefix, $key], fn (string $k) => strlen($k) > 0));
 
             if (is_array($item)) {
                 foreach ($this->recursively($item, $keyWithPrefix) as [$subItem, $subItemKey]) {
@@ -76,7 +75,8 @@ trait HelperMethods
             '/\.\d{3}\b/' => '.v',
         ];
         $date = preg_replace(array_keys($patterns), array_values($patterns), $date);
-ray($date);
+        ray($date);
+
         return preg_match('/\d/', $date) ? false : $date;
     }
 
@@ -110,5 +110,31 @@ ray($date);
         $property->setAccessible(true);
 
         return $property;
+    }
+
+    /**
+     * Get an ordinal number from the integer.
+     *   1 => '1st'
+     *   2 => '2nd'
+     *   etc.
+     *
+     * @param int $number
+     *
+     * @return string
+     */
+    protected function ordinal(int $number): string
+    {
+        if (!in_array($number % 100, [11, 12, 13])) {
+            switch ($number % 10) {
+                case 1:
+                    return $number . 'st';
+                case 2:
+                    return $number . 'nd';
+                case 3:
+                    return $number . 'rd';
+            }
+        }
+
+        return $number . 'th';
     }
 }

--- a/src/SwaggerServiceProvider.php
+++ b/src/SwaggerServiceProvider.php
@@ -31,6 +31,9 @@ class SwaggerServiceProvider extends PackageServiceProvider
     {
         $this->aliasMiddleware('tag', SwaggerTag::class);
         $this->aliasMiddleware('reader', SwaggerReader::class);
+
+        // Making the reader a singleton ensures that the executed rules still get stored.
+        $this->app->singleton(SwaggerReader::class);
     }
 
     /**

--- a/tests/Unit/Actions/BuildOpenApiConfigActionTest.php
+++ b/tests/Unit/Actions/BuildOpenApiConfigActionTest.php
@@ -322,4 +322,28 @@ class BuildOpenApiConfigActionTest extends TestCase
             $result
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_displays_a_separate_server_on_the_path_when_the_batch_has_a_route_domain()
+    {
+        Batch::factory(['route_uri' => 'products', 'route_method' => 'GET', 'response_code' => 204, 'route_domain' => 'echo.example.com'])
+            ->has(Entry::factory()->validation())
+            ->has(Entry::factory()->response())
+            ->has(Entry::factory()->parameters())
+            ->create();
+
+        /** @var BuildOpenApiConfigAction $action */
+        $action = resolve(BuildOpenApiConfigAction::class);
+
+        $result = $action->build();
+
+        $this->assertArrayHasKeys(
+            [
+                'paths./products.get.servers.0.url' => 'echo.example.com',
+            ],
+            $result
+        );
+    }
 }

--- a/tests/Unit/Actions/ReadRouteInformationActionTest.php
+++ b/tests/Unit/Actions/ReadRouteInformationActionTest.php
@@ -242,6 +242,29 @@ class ReadRouteInformationActionTest extends TestCase
      }
 
     /**
+     * @test
+     */
+    public function it_stores_the_where_statements_when_a_route_has_them()
+    {
+        /** @var ReadRouteInformationAction $action */
+        $action = resolve(ReadRouteInformationAction::class);
+        $batch = Batch::factory()->create();
+        $request = new Request();
+        $route = Route::get('batches/{batch}', fn () => response()->noContent())->bind($request)
+            ->where('batch', '[0-9]+');
+        $route->setParameter('batch', $batch);
+
+        $action->read($request, $route, response()->noContent());
+
+        $this->assertDatabaseHas('swagger_entries', [
+            'type'    => Entry::TYPE_ROUTE_WHERES,
+            'content' => json_encode([
+                'batch' => '[0-9]+',
+            ]),
+        ]);
+    }
+
+    /**
      * @return Closure[][]
      */
     public function responses(): array

--- a/tests/Unit/Actions/ReadRouteInformationActionTest.php
+++ b/tests/Unit/Actions/ReadRouteInformationActionTest.php
@@ -224,6 +224,24 @@ class ReadRouteInformationActionTest extends TestCase
     }
 
     /**
+     * @test
+     */
+     public function when_the_route_has_a_separate_domain_it_is_stored_in_the_batch()
+     {
+         /** @var ReadRouteInformationAction $action */
+         $action = resolve(ReadRouteInformationAction::class);
+         $request = new Request();
+         $route = Route::domain('other.example.com')->get('batches', fn () => response()->noContent())->bind($request);
+
+         $action->read($request, $route, response()->noContent());
+
+         /** @var Batch $batch */
+         $batch = Batch::query()->latest()->firstOrFail();
+
+         $this->assertNotNull($batch->route_domain);
+     }
+
+    /**
      * @return Closure[][]
      */
     public function responses(): array

--- a/tests/Unit/Data/PathDataTest.php
+++ b/tests/Unit/Data/PathDataTest.php
@@ -208,7 +208,7 @@ class PathDataTest extends TestCase
     /**
      * @test
      */
-    public function it_does_stores_an_empty_array_of_parameters_when_the_batch_does_not_have_an_entry_for_parameters()
+    public function it_stores_an_empty_array_of_parameters_when_the_batch_does_not_have_an_entry_for_parameters()
     {
         $batch = Batch::factory(['route_uri' => 'batches/{batch}'])
             ->has(Entry::factory()->response())
@@ -221,5 +221,26 @@ class PathDataTest extends TestCase
 
         $this->assertIsArray($parameters);
         $this->assertEmpty($parameters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_a_server_when_the_route_domain_column_is_set()
+    {
+        /** @var Batch $batch */
+        $batch = Batch::factory(['route_uri' => 'products', 'route_method' => 'GET', 'response_code' => 204, 'route_domain' => 'echo.example.com'])
+            ->has(Entry::factory()->validation())
+            ->has(Entry::factory()->response())
+            ->has(Entry::factory()->parameters())
+            ->create();
+
+        $data = new PathData($batch);
+
+        $servers = $this->property($data, 'servers')->getValue($data);
+
+        $this->assertIsArray($servers);
+        $this->assertCount(1, $servers);
+        $this->assertArrayHasKeys(['0.url' => 'echo.example.com'], $servers);
     }
 }

--- a/tests/Unit/Exceptions/MalformedServersExceptionTest.php
+++ b/tests/Unit/Exceptions/MalformedServersExceptionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace RicoNijeboer\Swagger\Tests\Unit\Exceptions;
+
+use Illuminate\Support\MessageBag;
+use RicoNijeboer\Swagger\Exceptions\MalformedServersException;
+use RicoNijeboer\Swagger\Tests\TestCase;
+
+/**
+ * Class MalformedServersExceptionTest
+ *
+ * @package RicoNijeboer\Swagger\Tests\Unit\Exceptions
+ */
+class MalformedServersExceptionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_formats_the_message_nicely()
+    {
+        $messageBag = new MessageBag([
+            'servers.0.url'                  => ['The servers.0.url is required.'],
+            'servers.0.variables.customerId' => ['The servers.0.variables.customerId must be an array.'],
+            'servers.0.variables.port'       => ['The servers.0.variables.port must be an array.'],
+        ]);
+
+        $exception = new MalformedServersException($messageBag);
+
+        $message = $exception->getMessage();
+
+        $this->assertStringStartsWith('Whoops. Looks like something went wrong while reading your Swagger servers configuration', $message);
+        $this->assertStringContainsString('The [url] is required.', $message);
+        $this->assertStringContainsString('The variable [port] must be an array.', $message);
+        $this->assertStringContainsString('The variable [customerId] must be an array.', $message);
+    }
+
+    /**
+     * @test
+     */
+    public function it_groups_the_errors_per_server()
+    {
+        $messageBag = new MessageBag([
+            'servers.0.url' => ['The servers.0.url is required.'],
+            'servers.1.url' => ['The servers.1.url is required.'],
+            'servers.2.url' => ['The servers.2.url is required.'],
+            'servers.3.url' => ['The servers.3.url is required.'],
+        ]);
+
+        $exception = new MalformedServersException($messageBag);
+
+        $message = $exception->getMessage();
+
+        $this->assertStringContainsString('Validation failed with errors for the 1st server', $message);
+        $this->assertStringContainsString('Validation failed with errors for the 2nd server', $message);
+        $this->assertStringContainsString('Validation failed with errors for the 3rd server', $message);
+        $this->assertStringContainsString('Validation failed with errors for the 4th server', $message);
+    }
+}

--- a/tests/Unit/Http/Middleware/SwaggerReaderTest.php
+++ b/tests/Unit/Http/Middleware/SwaggerReaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RicoNijeboer\Swagger\Tests\Unit\Middleware;
+namespace RicoNijeboer\Swagger\Tests\Unit\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Http/Middleware/SwaggerReaderTest.php
+++ b/tests/Unit/Http/Middleware/SwaggerReaderTest.php
@@ -25,7 +25,7 @@ class SwaggerReaderTest extends TestCase
     /**
      * @test
      */
-    public function it_registers_an_on_validate_handler_when_enabled()
+    public function it_registers_an_on_validate_handler()
     {
         /** @var SwaggerReader $middleware */
         $middleware = resolve(SwaggerReader::class);
@@ -73,7 +73,11 @@ class SwaggerReaderTest extends TestCase
         );
         $middleware = new SwaggerReader($readAction);
 
+        // Simulate executing middleware while a user is waiting
         $middleware->handle($request, $action);
+
+        // Simulate what happens after a response has been sent
+        $middleware->terminate($request, $response);
     }
 
     /**
@@ -105,7 +109,11 @@ class SwaggerReaderTest extends TestCase
         );
         $middleware = new SwaggerReader($readAction);
 
+        // Simulate executing middleware while a user is waiting
         $middleware->handle($request, $action);
+
+        // Simulate what happens after a response has been sent
+        $middleware->terminate($request, $response);
     }
 
     /**
@@ -151,7 +159,7 @@ class SwaggerReaderTest extends TestCase
                 ->bind($request);
         });
 
-        $middleware->handle($request, fn () => response()->noContent());
+        $middleware->terminate($request, response()->noContent());
 
         $this->assertDatabaseMissing('swagger_batches', [
             'id' => $batch->id,
@@ -179,7 +187,7 @@ class SwaggerReaderTest extends TestCase
         /** @var SwaggerReader $middleware */
         $middleware = resolve(SwaggerReader::class);
 
-        $middleware->handle($request, $action, 'tag-one', 'tag-two');
+        $middleware->terminate($request, $response, 'tag-one', 'tag-two');
 
         $this->assertDatabaseHas('swagger_tags', ['tag' => 'tag-one']);
         $this->assertDatabaseHas('swagger_tags', ['tag' => 'tag-two']);

--- a/tests/Unit/Http/Middleware/SwaggerTagTest.php
+++ b/tests/Unit/Http/Middleware/SwaggerTagTest.php
@@ -37,7 +37,11 @@ class SwaggerTagTest extends TestCase
             ->{strtolower($batch->route_method)}($batch->route_uri, fn () => $response)
             ->middleware($batch->route_middleware));
 
+        // Simulate executing middleware while a user is waiting
         $middleware->handle($request, fn () => $response, 'add');
+
+        // Simulate what happens after a response has been sent
+        $middleware->terminate($request, $response, 'add');
 
         $this->assertDatabaseHas('swagger_tags', [
             'tag' => 'add',

--- a/tests/Unit/Http/Middleware/SwaggerTagTest.php
+++ b/tests/Unit/Http/Middleware/SwaggerTagTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RicoNijeboer\Swagger\Tests\Unit\Middleware;
+namespace RicoNijeboer\Swagger\Tests\Unit\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Support/RuleHelperTest.php
+++ b/tests/Unit/Support/RuleHelperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace RicoNijeboer\Swagger\Tests\Unit\Support;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use RicoNijeboer\Swagger\Support\RuleHelper;
+use RicoNijeboer\Swagger\Tests\TestCase;
+
+/**
+ * Class RuleHelperTest
+ *
+ * @package RicoNijeboer\Swagger\Tests\Unit\Support
+ */
+class RuleHelperTest extends TestCase
+{
+    /**
+     * @test
+     * @throws ValidationException
+     */
+    public function it_adds_a_format_rule_to_strings_that_have_a_regex_rule()
+    {
+        $rules = [
+            'required',
+            'string',
+            'regex:/[0-9]+\_[a-z]/',
+        ];
+
+        // Ensure rules used actually work in Laravel (It will throw a validation exception if it does not).
+        Validator::make(['field' => '012_a'], ['field' => $rules])->validate();
+
+        $result = RuleHelper::openApiProperty('field', $rules, []);
+
+        $this->assertArrayHasKeys(['format' => '[0-9]+\_[a-z]'], $result);
+    }
+}


### PR DESCRIPTION
### Changes

- When a field in your request validation has a [`regex`](https://laravel.com/docs/8.x/validation#rule-regex) rule. It gets a `format` rule within the Swagger config.
- When a route-parameter has a [`where`](https://laravel.com/docs/8.x/routing#parameters-regular-expression-constraints) (or `format` in Swagger terms) it now adds this in the Swagger config.
- Added support for [server templating](https://github.com/RicoNijeboer/laravel-to-swagger/issues/4).
- OAuth URLs are now relative when you don't supply a custom domain to them.
- When a route has a custom domain using `->domain(...)` it is now displayed in the Swagger config.
- The `SwaggerReader` and `SwaggerTag` are now [Terminable Middlewares](https://laravel.com/docs/8.x/middleware#terminable-middleware), which means your users should feel even less of an impact when using your app

### Upgrading

- When updating to this version add an alter migration for the `swagger_batches` table which adds a nullable `route_domain` string-column   
  `$table->string('route_domain')->nullable();`